### PR TITLE
Utvid feilmeldingSchema med nye feilkoder fra fp-felles

### DIFF
--- a/app/src/types/api-models.ts
+++ b/app/src/types/api-models.ts
@@ -257,6 +257,10 @@ export const feilmeldingSchema = z.object({
       "MANGLER_TILGANG_FEIL",
       "SENDT_FOR_TIDLIG",
       "FINNES_I_AAREG",
+      "GENERELL",
+      "IKKE_TILGANG",
+      "IKKE_FUNNET",
+      "VALIDERING",
     ])
     .optional(),
 });


### PR DESCRIPTION
Legger til GENERELL, IKKE_TILGANG, IKKE_FUNNET og VALIDERING i feilmeldingSchema type-enum slik at frontend aksepterer de nye feilkodene som backend snart vil returnere.