### PR TITLE
Add startup-hook, remove cpu-limit, scale faster

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -22,12 +22,16 @@ spec:
     path: /internal/health/isReady
     initialDelay: 10
     timeout: 1
+  startup:
+    path: /internal/health/isReady
+    initialDelay: 10
+    timeout: 1
   replicas:
     min: {{minReplicas}}
     max: {{maxReplicas}}
     scalingStrategy:
       cpu:
-        thresholdPercentage: 80
+        thresholdPercentage: 50
   resources:
     limits:
       memory: {{limits.memory}}


### PR DESCRIPTION
Setter standard skalering ved 50% - men kan godt hende vi skal gå for statisk antall noder og skippe autoscaling
Legger på startup-hook for å unngå at oppstart skalerer til max og så ned.