### PR TITLE
fix: vis Tariffendring som årsak når IM er sendt via LPS/Altinn

### DIFF
--- a/app/src/features/inntektsmelding/Steg2InntektOgRefusjon.tsx
+++ b/app/src/features/inntektsmelding/Steg2InntektOgRefusjon.tsx
@@ -81,8 +81,11 @@ export function Steg2InntektOgRefusjon() {
     useInntektsmeldingSkjema();
 
   const { eksisterendeInntektsmeldinger } = useLoaderData({ from: "/$id" });
+  // Regn også LPS/Altinn-sendte IM-er som eksisterende (de vises ikke i API-listen,
+  // men forespørselStatus er "FERDIG" når en IM er mottatt fra eksternt system)
   const harEksisterendeInntektsmeldinger =
-    eksisterendeInntektsmeldinger.length > 0;
+    eksisterendeInntektsmeldinger.length > 0 ||
+    opplysninger.forespørselStatus === "FERDIG";
 
   const defaultInntekt =
     inntektsmeldingSkjemaState.inntekt ||


### PR DESCRIPTION
Endepunktet /imdialog/inntektsmeldinger returnerer kun IM-er sendt via nav.no. For IM-er sendt via LPS eller Altinn er listen tom, og harEksisterendeInntektsmeldinger ble feilaktig false.

Bruker forespørselStatus === 'FERDIG' som ekstra signal – konsistent med logikken i Steg1DineOpplysninger.tsx.