### PR TITLE
fix: legg til nav-dekoratoren i filter for kjente feil

### DIFF
--- a/app/src/initFaro.ts
+++ b/app/src/initFaro.ts
@@ -23,7 +23,10 @@ type ExceptionItem = FaroItem & {
   payload: ExceptionPayload;
 };
 
-const FEIL_VI_VIL_LUKE_BORT = ["personbruker/decorator-next"];
+const FEIL_VI_VIL_LUKE_BORT = [
+  "personbruker/decorator-next",
+  "personbruker/nav-dekoratoren",
+];
 
 const DISTRIBUTOR_PATTERN = /Request timeout \S*Distributor\.\S+/;
 


### PR DESCRIPTION
## Hva
Legger til `personbruker/nav-dekoratoren` i listen over kjente feil som filtreres bort fra observability (Faro), på samme måte som `personbruker/decorator-next` allerede filtreres.

## Hvorfor
Vi ønsker ikke støy fra dekoratør-relaterte feil vi ikke kan gjøre noe med.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>