### PR TITLE
fix: filtrer bort alt fra dekoratøren uavhengig av filsti-mønster

### DIFF
--- a/app/src/initFaro.ts
+++ b/app/src/initFaro.ts
@@ -100,23 +100,25 @@ const feilUtenOpprinnelseIVårKode = (item: ExceptionItem): boolean => {
 /**
  * Sjekker om stackframes mangler opprinnelse i vår kode.
  *
- * Logikk: Hvis en frame er fra et asset (`/assets/*.js`) og matcher
- * FEIL_VI_VIL_LUKE_BORT, er det en uønsket asset-frame → filtrer.
- * Hvis framen er fra våre egne assets → ikke filtrer.
- * Hvis framen ikke er et asset (ikke fra vår bundle) → filtrer.
+ * Logikk: Hvis en frame kommer fra dekoratøren (filnavnet inneholder noe fra
+ * FEIL_VI_VIL_LUKE_BORT, uavhengig av filtype/plassering) → filtrer. Dette
+ * fanger opp alt fra dekoratøren, ikke bare bundlede `/assets/*.js`-chunks
+ * (f.eks. rå kildefiler som `personbruker/nav-dekoratoren/src/helpers/auth.ts`).
+ * Hvis framen er fra vårt eget asset (`/assets/*.js`) → ikke filtrer.
+ * Hvis framen verken er fra dekoratøren eller vårt eget asset → filtrer.
  */
 const harUtenforstaendeKodeOpprinnelse = (frames: StackFrame[]): boolean => {
   return frames.some((frame) => {
+    const erDekoratørFrame = FEIL_VI_VIL_LUKE_BORT.some((feil) =>
+      frame.filename?.includes(feil),
+    );
+    if (erDekoratørFrame) {
+      return true;
+    }
+
     const assetFrame =
       frame.filename && /\/assets\/.*\.js$/.test(frame.filename);
-
-    if (assetFrame) {
-      const erUønsketAssetFrame = FEIL_VI_VIL_LUKE_BORT.some((feil) =>
-        frame.filename?.includes(feil),
-      );
-      return erUønsketAssetFrame;
-    }
-    return true;
+    return !assetFrame;
   });
 };
 


### PR DESCRIPTION
## Hva
Generaliserer dekoratør-filteret i \`harUtenforstaendeKodeOpprinnelse\` slik at det fanger opp **alle** stacktrace-frames som stammer fra dekoratøren, ikke bare bundlede \`/assets/*.js\`-chunks.

## Hvorfor
Vi observerte en exception (\"Failed to renew session\") fra dekoratørens auth-logikk (fanget opp via \`@nais/apm\`s console.error-interceptor) som ikke ble filtrert bort, fordi stacktracen pekte til rå kildefiler (\`personbruker/nav-dekoratoren/src/helpers/auth.ts\`) i stedet for et bundlet asset under \`/assets/\`.

I stedet for å hardkode mot dekoratørens feiltekster, filtrerer vi nå på **opprinnelses-sti** (\`FEIL_VI_VIL_LUKE_BORT\`) uavhengig av filtype/plassering — så alt som kommer fra dekoratøren luker vi bort, uansett hvordan det havner i Faro.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>