### PR TITLE
TFP-6363: bruk GITHUB_TOKEN i stedet for READER_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build
     permissions:
       contents: read
-      packages: write
+      packages: read
       id-token: write
     runs-on: "ubuntu-latest"
     env:
@@ -43,7 +43,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
         working-directory: server
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build server
         run: pnpm run build
@@ -53,7 +53,7 @@ jobs:
         working-directory: app
         run: pnpm install --frozen-lockfile --ignore-scripts
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate build version
         id: generate-build-version
@@ -106,7 +106,6 @@ jobs:
       cluster: dev-gcp
       naiserator_file: "naiserator.yaml"
       namespace: teamforeldrepenger
-    secrets: inherit
 
   deploy-prod:
     if: github.ref == 'refs/heads/master'
@@ -121,4 +120,3 @@ jobs:
       cluster: prod-gcp
       naiserator_file: "naiserator.yaml"
       namespace: teamforeldrepenger
-    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
+
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6
+
       - name: Set up NODE
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
@@ -73,6 +73,7 @@ jobs:
       - name: Copy webapp into public directory of server
         working-directory: app
         run: cp -r dist/ ../server/public
+
       - name: Bygg og push docker image teamforeldrepenger
         uses: navikt/fp-gha-workflows/.github/actions/build-push-docker-image@main # ratchet:exclude
         with:

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     name: Run end to end tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6
@@ -27,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
@@ -42,6 +45,9 @@ jobs:
   verify:
     name: Verify there are no lint or typescript errors
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6
@@ -53,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Knip
         run: pnpm run knip

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -21,12 +21,15 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 26
           registry-url: https://npm.pkg.github.com/
           scope: "@navikt"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
         env:
@@ -34,14 +37,17 @@ jobs:
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
+
       - name: Run Playwright tests
         run: pnpm exec playwright test
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
   verify:
     name: Verify there are no lint or typescript errors
     runs-on: ubuntu-latest
@@ -50,12 +56,15 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 26
           registry-url: https://npm.pkg.github.com/
           scope: "@navikt"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
         env:

--- a/.github/workflows/verify-server.yml
+++ b/.github/workflows/verify-server.yml
@@ -16,6 +16,9 @@ jobs:
   verify:
     name: Verify there are no lint or typescript errors
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6
@@ -28,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Knip
         run: pnpm run knip

--- a/.github/workflows/verify-server.yml
+++ b/.github/workflows/verify-server.yml
@@ -21,7 +21,9 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 26


### PR DESCRIPTION
## Hva
Migrerer GitHub Actions-workflows fra `READER_TOKEN` (PAT) til det kortlevde `GITHUB_TOKEN` med least-privilege.

- **verify-app.yml / verify-server.yml**: `NODE_AUTH_TOKEN` → `GITHUB_TOKEN`, og eksplisitt `permissions: { contents: read, packages: read }` på jobbene (trengs for å hente `@navikt`-pakker via `GITHUB_TOKEN`).
- **build.yml**: `NODE_AUTH_TOKEN` → `GITHUB_TOKEN`, `packages: write` → `read` (docker pushes til GAR via `nais`, ikke GitHub Packages), og fjernet unødvendig `secrets: inherit` fra deploy-jobbene (`deploy.yml` bruker ingen secrets; deploy via OIDC).

## Ikke inkludert
Dependabot beholder `READER_TOKEN` (egen secret-mekanisme).